### PR TITLE
resolves 11: Add Typst support and configuration for NumPEx templates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+    "[typst]": {
+        "editor.defaultFormatter": "myriad-dreamin.tinymist",
+        "editor.formatOnSave": true
+    },
     "latex-workshop.latex.recipes": [
         {
             "name": "xelatex",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,35 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Typst: watch presentation (local fonts)",
+      "type": "shell",
+      "command": "./scripts/typst-watch.sh",
+      "args": ["presentation.template.typ"],
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "Typst: compile presentation (local fonts)",
+      "type": "shell",
+      "command": "./scripts/typst-compile.sh",
+      "args": ["presentation.template.typ"],
+      "problemMatcher": []
+    },
+    {
+      "label": "Typst: watch poster (local fonts)",
+      "type": "shell",
+      "command": "./scripts/typst-watch.sh",
+      "args": ["poster.template.typ"],
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "Typst: compile poster (local fonts)",
+      "type": "shell",
+      "command": "./scripts/typst-compile.sh",
+      "args": ["poster.template.typ"],
+      "problemMatcher": []
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,92 @@
+# Makefile for NUMPEX presentation/poster templates
+# Supports both LaTeX and Typst builds with separate output directories
+
+# Directories
+TEX_OUT = build/tex
+TYPST_OUT = build/typst
+
+# Source files
+TEX_SOURCES = presentation.template.tex poster.template.tex
+TYPST_SOURCES = presentation.template.typ poster.template.typ
+
+# Output PDFs
+TEX_PDFS = $(TEX_OUT)/presentation.template.pdf $(TEX_OUT)/poster.template.pdf
+TYPST_PDFS = $(TYPST_OUT)/presentation.template.pdf $(TYPST_OUT)/poster.template.pdf
+
+.PHONY: all tex typst clean clean-tex clean-typst dirs help
+
+# Default: build both
+all: tex typst
+
+# Create output directories
+dirs:
+	@mkdir -p $(TEX_OUT) $(TYPST_OUT)
+
+# Build all LaTeX documents
+tex: dirs $(TEX_PDFS)
+
+# Build all Typst documents
+typst: dirs $(TYPST_PDFS)
+
+# LaTeX build rules (uses latexmk with .latexmkrc config)
+$(TEX_OUT)/%.pdf: %.tex
+	latexmk -pdf $<
+
+# Typst build rules (multiple font paths for Marianne and Roboto static fonts)
+$(TYPST_OUT)/%.pdf: %.typ numpex.typ
+	typst compile --root . --font-path fonts/Marianne/desktop --font-path fonts/Roboto/static $< $@
+
+# Convenience targets for individual documents
+presentation-tex: dirs $(TEX_OUT)/presentation.template.pdf
+presentation-typst: dirs $(TYPST_OUT)/presentation.template.pdf
+poster-tex: dirs $(TEX_OUT)/poster.template.pdf
+poster-typst: dirs $(TYPST_OUT)/poster.template.pdf
+
+# Watch modes for live editing
+watch-presentation-tex:
+	latexmk -pvc -pdf presentation.template.tex
+
+watch-presentation-typst:
+	typst watch --root . --font-path fonts/Marianne/desktop --font-path fonts/Roboto/static presentation.template.typ $(TYPST_OUT)/presentation.template.pdf
+
+watch-poster-tex:
+	latexmk -pvc -pdf poster.template.tex
+
+watch-poster-typst:
+	typst watch --root . --font-path fonts/Marianne/desktop --font-path fonts/Roboto/static poster.template.typ $(TYPST_OUT)/poster.template.pdf
+
+# Clean targets
+clean: clean-tex clean-typst
+
+clean-tex:
+	latexmk -C
+	rm -rf $(TEX_OUT)
+
+clean-typst:
+	rm -rf $(TYPST_OUT)
+
+# Help
+help:
+	@echo "NUMPEX Presentation/Poster Templates Build System"
+	@echo ""
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Build targets:"
+	@echo "  all                 Build both TeX and Typst (default)"
+	@echo "  tex                 Build all LaTeX documents -> $(TEX_OUT)/"
+	@echo "  typst               Build all Typst documents -> $(TYPST_OUT)/"
+	@echo "  presentation-tex    Build presentation with LaTeX"
+	@echo "  presentation-typst  Build presentation with Typst"
+	@echo "  poster-tex          Build poster with LaTeX"
+	@echo "  poster-typst        Build poster with Typst"
+	@echo ""
+	@echo "Watch modes (auto-rebuild on changes):"
+	@echo "  watch-presentation-tex"
+	@echo "  watch-presentation-typst"
+	@echo "  watch-poster-tex"
+	@echo "  watch-poster-typst"
+	@echo ""
+	@echo "Clean targets:"
+	@echo "  clean               Clean all build artifacts"
+	@echo "  clean-tex           Clean LaTeX artifacts only"
+	@echo "  clean-typst         Clean Typst artifacts only"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# A Beamer Template for NumPEx Presentations
+# NumPEx Presentation & Poster Templates (LaTeX + Typst)
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15113190.svg)](https://doi.org/10.5281/zenodo.15113190)
 [![GitHub Release](https://img.shields.io/github/v/release/numpex/presentation.template)](https://github.com/numpex/presentation.template/releases/latest)
@@ -41,6 +41,53 @@ Compile `poster.template.tex`:
 article-cli compile --engine xelatex poster.template.tex
 ```
 
+## Typst (VS Code)
+
+This repository also includes Typst equivalents:
+
+- Presentation: `presentation.template.typ`
+- Poster: `poster.template.typ`
+
+### Recommended VS Code extension
+
+Install **Tinymist Typst** (`myriad-dreamin.tinymist`). It provides syntax highlighting, diagnostics, formatting, and the preview.
+
+This repo already ships a minimal formatter setup in `.vscode/settings.json`.
+
+### Install Typst (macOS)
+
+The most reliable setup is to install the Typst compiler via Homebrew:
+
+```bash
+brew install typst
+```
+
+Optional:
+
+```bash
+brew install typstfmt
+```
+
+### Does it compile automatically?
+
+- When the **Preview** is open, Tinymist typically re-compiles on edits/saves.
+- If the preview is blank, it usually means there is a compilation error.
+
+### Preview and build from the CLI
+
+From the repository root:
+
+```bash
+typst compile presentation.template.typ --root .
+typst compile poster.template.typ --root .
+```
+
+### Blank preview troubleshooting
+
+- Open the **Problems** panel (compilation errors show up there).
+- Open the **Output** panel and select **Tinymist** to see the compiler logs.
+- Make sure you preview the entrypoint (`presentation.template.typ` or `poster.template.typ`), not the theme/library file.
+
 ## Fonts
 
 For the best result, you should install the [Marianne font](https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-de-l-identite-de-l-etat/typographie/) and compile with XeLaTeX.
@@ -54,6 +101,33 @@ article-cli install-fonts
 ```
 
 This downloads and extracts the fonts into the `fonts/` directory within your project. The `beamerfontthemenumpex` package is already configured to use fonts from this relative path.
+
+### Typst fonts
+
+Typst uses the fonts installed on your system. For best results, install **Marianne** (and a mono font like **Roboto Mono**) system-wide.
+
+### Typst fonts (repo-local, no system install)
+
+If you want a fully local setup (use the committed fonts in `fonts/` without installing anything into macOS Font Book), use Typst with explicit font paths.
+
+This repository provides helper scripts and VS Code tasks that pass:
+
+- `--font-path fonts/Marianne/desktop`
+- `--font-path fonts/Roboto/static`
+
+CLI:
+
+```bash
+./scripts/typst-compile.sh presentation.template.typ
+./scripts/typst-watch.sh presentation.template.typ
+```
+
+VS Code:
+
+- Run **Terminal → Run Task…**
+- Choose **Typst: watch presentation (local fonts)** or **Typst: watch poster (local fonts)**
+
+This gives you automatic rebuilds and correct fonts without system installation. You can open the generated PDF in any viewer while `typst watch` runs.
 
 ### Manual Font Configuration
 

--- a/numpex.typ
+++ b/numpex.typ
@@ -1,0 +1,535 @@
+// NumPEx Typst Presentation Theme
+// Based on the French State Graphic Charter (Charte graphique de l'État Français)
+// Copyright 2024-2025 NumPEx Project
+// Licensed under MIT License
+
+// Slide helper (Typst-native): create one page per slide.
+// We avoid depending on external presentation frameworks for now so the
+// template works out-of-the-box.
+// Using pagebreak(weak: true) ensures no blank page at the start while
+// still separating subsequent slides.
+#let polylux-slide(body) = {
+  pagebreak(weak: true)
+  body
+}
+
+// ============================================================================
+// Color Definitions (French State Colors)
+// ============================================================================
+
+#let nblue = rgb("#000091")    // French blue - primary structural color
+#let nred = rgb("#E1000F")     // French red - alerts and accents
+#let ngreen = rgb("#467248")   // Forest green - code strings
+#let npurple = rgb("#6E445A")  // Purple - secondary accent
+#let accent-teal = rgb("#008B8B")  // Teal - example blocks
+
+#let gray30 = rgb(30%, 30%, 30%)
+#let gray60 = rgb(60%, 60%, 60%)
+#let gray80 = rgb(85%, 85%, 85%)
+
+// ============================================================================
+// Font Configuration
+// ============================================================================
+
+#let marianne-regular = "Marianne"
+#let marianne-light = "Marianne Light"
+#let marianne-bold = "Marianne Bold"
+#let marianne-medium = "Marianne Medium"
+
+// Note: Typst selects weights (light/regular/bold/...) within a family.
+// When compiling with `--font-path fonts/Marianne/desktop`, the family is
+// typically exposed as "Marianne".
+// Roboto Mono is provided in this repo under fonts/Roboto/static.
+
+// Font fallbacks for systems without Marianne
+#let sans-fonts = ("Marianne", "Helvetica Neue", "Arial")
+#let mono-fonts = ("Roboto Mono", "Fira Code", "Consolas")
+
+// ============================================================================
+// Slide Dimensions and Margins
+// ============================================================================
+
+#let slide-width = 160mm   // Beamer 16:9 dimensions
+#let slide-height = 90mm
+
+// Beamer theme uses 0.06\paperwidth for left/right text margins.
+// Here we compute it from the fixed slide width (160mm).
+#let margin-x = 0.06 * slide-width
+// Beamer theme sets \leftmargini = 0.6 * normalmargin.
+#let list-indent = 0.6 * margin-x
+
+// Beamer footline uses ht=3ex, dp=3ex (≈ 6ex total).
+// With 10pt base font: 1ex ≈ 4.3pt, so 6ex ≈ 25.8pt ≈ 0.9cm
+#let footline-height = 0.9cm
+
+// ============================================================================
+// Theme State
+// ============================================================================
+
+#let numpex-config = state("numpex-config", (
+  title: none,
+  short-title: none,
+  author: none,
+  short-author: none,
+  date: none,
+  institution: none,
+))
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+#let numpex-logo(height: 1cm, name) = {
+  image("images/" + name, height: height)
+}
+
+// ============================================================================
+// Title Slide
+// ============================================================================
+
+#let title-slide(
+  title: none,
+  subtitle: none,
+  author: none,
+  date: none,
+  institution: none,
+) = {
+  // Store metadata for footline
+  numpex-config.update(cfg => {
+    cfg.title = title
+    cfg.author = author
+    cfg.date = date
+    cfg.institution = institution
+    cfg
+  })
+
+  polylux-slide[
+    #set page(margin: 0pt)
+
+    // White header bar at top
+    #place(top)[
+      #box(width: 100%, height: 1.5cm, fill: white)
+    ]
+
+    // Background image (below header)
+    #place(top, dy: 1.5cm)[
+      #image("images/back1.jpg", width: 100%)
+    ]
+
+    // Top left: République Française logo (on white header)
+    #place(top + left, dx: 0.5cm, dy: 0.1cm)[
+      #image("images/rf.png", height: 1.3cm)
+    ]
+
+    // Top right: Partner logos (CEA, CNRS, INRIA) (on white header)
+    #place(top + right, dx: -0.3cm, dy: 0.15cm)[
+      #stack(
+        dir: ltr,
+        spacing: 0.2cm,
+        image("images/cea.jpg", height: 1cm),
+        image("images/cnrs.png", height: 1cm),
+        image("images/inria.png", height: 0.9cm),
+      )
+    ]
+
+    // Left: France 2030 logo (centered vertically in background area)
+    #place(left + horizon, dx: 0.8cm, dy: 0.5cm)[
+      #image("images/f2030_white.png", height: 2cm)
+    ]
+
+    // Right: Title block
+    #place(right + horizon, dx: -0.5cm, dy: 0.5cm)[
+      #box(width: 60%)[
+        #set align(left)
+        #set text(fill: white)
+
+        #if title != none [
+          #text(size: 18pt, weight: "regular", title)
+          #v(0.4em)
+        ]
+
+        #if subtitle != none [
+          #text(size: 10pt, weight: "light", subtitle)
+          #v(0.4em)
+        ]
+
+        #if author != none [
+          #text(size: 8pt, weight: "light", author)
+          #v(0.2em)
+        ]
+
+        #if date != none [
+          #text(size: 8pt, weight: "light", date)
+        ]
+
+        #if institution != none [
+          #v(1.5mm)
+          #text(size: 8pt, weight: "light", institution)
+        ]
+      ]
+    ]
+  ]
+}
+
+// ============================================================================
+// Section Slide
+// ============================================================================
+
+#let section-slide(title) = {
+  polylux-slide[
+    #set page(margin: 0pt)
+
+    // White header bar at top
+    #place(top)[
+      #box(width: 100%, height: 1.5cm, fill: white)
+    ]
+
+    // Top left: RF + France 2030 logos (on white header)
+    #place(top + left, dx: 0.2cm, dy: 0.1cm)[
+      #stack(dir: ltr, spacing: 0.15cm, image("images/rf.png", height: 1.3cm), image("images/f2030.png", height: 1.3cm))
+    ]
+
+    // Top right: Partner logos (on white header)
+    #place(top + right, dx: -0.3cm, dy: 0.15cm)[
+      #stack(
+        dir: ltr,
+        spacing: 0.2cm,
+        image("images/cea.jpg", height: 1cm),
+        image("images/cnrs.png", height: 1cm),
+        image("images/inria.png", height: 0.9cm),
+      )
+    ]
+
+    // Background image (below header)
+    #place(top, dy: 1.5cm)[
+      #image("images/back2.jpg", width: 100%)
+    ]
+
+    // Section title (centered in background area)
+    #place(center + horizon, dy: 0.5cm)[
+      #set text(fill: white, size: 22pt, weight: "regular")
+      #title
+    ]
+  ]
+}
+
+// ============================================================================
+// Footline
+// ============================================================================
+
+#let numpex-footline = context {
+  let cfg = numpex-config.get()
+  let current = here().page()
+
+  box(width: 100%, height: footline-height)[
+    #set align(horizon)
+    #set text(size: 7pt, fill: nblue)
+
+    #grid(
+      columns: (22.22%, 55.56%, 16.67%, 5.55%),
+      rows: (footline-height,),
+      align: (center + horizon, center + horizon, right + horizon, center + horizon),
+
+      // Logos (horizontal stack) - matching Beamer heights
+      stack(
+        dir: ltr,
+        spacing: 0.15cm,
+        image("images/cea.jpg", height: 0.6cm),
+        image("images/cnrs.png", height: 0.6cm),
+        image("images/inria.png", height: 0.5cm),
+      ),
+
+      // Title (no wrap)
+      box(clip: true)[#if cfg.title != none { cfg.title } else { "" }],
+
+      // Author (no wrap)
+      box(clip: true)[#if cfg.author != none { cfg.author } else { "" }],
+
+      // Page number
+      str(current),
+    )
+  ]
+}
+
+// ============================================================================
+// Regular Slide
+// ============================================================================
+
+#let slide(title: none, body) = {
+  polylux-slide[
+    // Footer should span the full slide width (like Beamer).
+    // We'll implement text margins inside the slide body instead.
+    #set page(
+      margin: (top: 0pt, bottom: footline-height, x: 0pt),
+      footer: numpex-footline,
+    )
+
+    // Frame title: full-width bar with compact padding.
+    #if title != none [
+      #box(width: 100%, inset: 0.25cm)[
+        #set text(size: 12pt, fill: nblue, weight: "regular")
+        #title
+      ]
+    ]
+
+    #v(0.2cm)
+
+    // Body content with Beamer-like left/right margins.
+    // Using a grid makes `width: 100%` resolve to the *text column* width.
+    #grid(
+      columns: (margin-x, 1fr, margin-x),
+      gutter: 0pt,
+      [], body, [],
+    )
+  ]
+}
+
+// ============================================================================
+// Plain Slide (for questions, etc.)
+// ============================================================================
+
+#let plain-slide(title: none, body: none) = {
+  polylux-slide[
+    #set page(
+      fill: white,
+      margin: (top: 0pt, bottom: footline-height, x: 0pt),
+      footer: numpex-footline,
+    )
+
+    #place(center + horizon)[
+      #set text(size: 18pt, fill: nblue, weight: "bold")
+      #if title != none { title } else { body }
+    ]
+  ]
+}
+
+// ============================================================================
+// Block Environments
+// ============================================================================
+
+#let block(title: none, body) = {
+  v(0.5em)
+  box(width: 100%)[
+    // Title bar
+    #if title != none [
+      #box(
+        width: 100%,
+        fill: nblue,
+        inset: 0.35em,
+      )[
+        #set text(fill: white, weight: "regular", size: 11pt)
+        #title
+      ]
+    ]
+
+    // Body
+    #box(
+      width: 100%,
+      fill: white,
+      inset: 0.35em,
+    )[
+      #body
+    ]
+
+    // Bottom bar
+    #box(
+      width: 100%,
+      fill: nblue,
+      height: 0.05cm,
+    )[]
+  ]
+  v(0.5em)
+}
+
+#let example-block(title: none, body) = {
+  v(0.5em)
+  box(width: 100%)[
+    // Title bar
+    #if title != none [
+      #box(
+        width: 100%,
+        fill: accent-teal.darken(30%),
+        inset: 0.35em,
+      )[
+        #set text(fill: white, weight: "regular", size: 11pt)
+        #title
+      ]
+    ]
+
+    // Body
+    #box(
+      width: 100%,
+      fill: accent-teal.lighten(95%),
+      inset: 0.35em,
+    )[
+      #body
+    ]
+
+    // Bottom bar
+    #box(
+      width: 100%,
+      fill: accent-teal.darken(30%),
+      height: 0.05cm,
+    )[]
+  ]
+  v(0.5em)
+}
+
+#let alert-block(title: none, body) = {
+  v(0.5em)
+  box(width: 100%)[
+    // Title bar
+    #if title != none [
+      #box(
+        width: 100%,
+        fill: nred,
+        inset: 0.35em,
+      )[
+        #set text(fill: white, weight: "regular", size: 11pt)
+        #title
+      ]
+    ]
+
+    // Body
+    #box(
+      width: 100%,
+      fill: nred.lighten(95%),
+      inset: 0.35em,
+    )[
+      #body
+    ]
+
+    // Bottom bar
+    #box(
+      width: 100%,
+      fill: nred,
+      height: 0.05cm,
+    )[]
+  ]
+  v(0.5em)
+}
+
+// ============================================================================
+// Text Styling
+// ============================================================================
+
+#let alert(body) = text(fill: nred, body)
+#let emph-text(body) = emph(body)
+
+// ============================================================================
+// Code Styling
+// ============================================================================
+
+#let code-block(lang: none, body) = {
+  set text(font: mono-fonts, size: 9pt)
+
+  box(
+    width: 100%,
+    fill: black.lighten(97%),
+    stroke: nblue,
+    inset: 1em,
+    radius: 0pt,
+  )[
+    #if lang != none {
+      raw(body, lang: lang, block: true)
+    } else {
+      raw(body, block: true)
+    }
+  ]
+}
+
+// ============================================================================
+// Theme Initialization
+// ============================================================================
+
+#let numpex-theme(
+  aspect-ratio: "16-9",
+  title: none,
+  short-title: none,
+  author: none,
+  short-author: none,
+  date: none,
+  institution: none,
+  body,
+) = {
+  // Store configuration
+  numpex-config.update(cfg => {
+    cfg.title = if short-title != none { short-title } else { title }
+    cfg.author = if short-author != none { short-author } else { author }
+    cfg.date = date
+    cfg.institution = institution
+    cfg
+  })
+
+  set document(
+    title: title,
+    author: author,
+  )
+
+  // Use Beamer's exact dimensions (160mm x 90mm) instead of Typst's preset
+  // This ensures the same aspect ratio and proportions as LaTeX Beamer
+  set page(
+    width: 160mm,
+    height: 90mm,
+    margin: 0pt,
+  )
+
+  // Font settings (matching Beamer 10pt base)
+  set text(
+    font: sans-fonts,
+    size: 10pt,
+    fill: black.lighten(3%),
+  )
+
+  // Paragraph settings
+  set par(justify: false)
+
+  // List styling (circular bullets)
+  set list(
+    marker: ([•], [◦], [•]),
+    indent: list-indent,
+  )
+
+  // Enumeration styling
+  set enum(indent: list-indent)
+
+  // Heading styling
+  show heading.where(level: 1): set text(fill: nblue, size: 14pt, weight: "regular")
+  show heading.where(level: 2): set text(fill: nblue, size: 12pt, weight: "regular")
+
+  // Link styling
+  show link: set text(fill: nred)
+
+  // Raw/code styling
+  show raw: set text(font: mono-fonts)
+  show raw.where(block: true): it => {
+    box(
+      width: 100%,
+      fill: black.lighten(97%),
+      stroke: nblue,
+      inset: 0.6em,
+    )[
+      #set text(size: 9pt)
+      #it
+    ]
+  }
+
+  // Table styling
+  set table(
+    stroke: none,
+    inset: 0.5em,
+  )
+
+  show table: it => {
+    set text(font: sans-fonts)
+    it
+  }
+
+  body
+}
+
+// ============================================================================
+// Convenience Exports
+// ============================================================================
+
+// Note: Polylux helpers can be imported directly by users if needed.

--- a/poster.template.typ
+++ b/poster.template.typ
@@ -1,0 +1,324 @@
+// NumPEx Poster Template for Typst
+// Equivalent to poster.template.tex
+// A0 format (841mm x 1189mm)
+
+#import "numpex.typ": accent-teal, alert, nblue, ngreen, npurple, nred
+
+// ============================================================================
+// Poster Configuration
+// ============================================================================
+
+#let poster-title = "A Poster Theme for NumPEx"
+#let poster-author = "Alfredo Buttari, Christophe Prud'homme"
+#let poster-institution = "Institute or Miscellaneous Information"
+#let poster-date = datetime.today().display("[month repr:long] [day], [year]")
+
+// ============================================================================
+// Page Setup
+// ============================================================================
+
+#set page(
+  paper: "a0",
+  margin: 0pt,
+  background: image("images/NumPEx_1.pdf", width: 100%, height: 100%),
+)
+
+#set text(
+  font: ("Marianne", "Inter", "Helvetica Neue", "Arial"),
+  size: 24pt,
+)
+
+#set par(justify: true)
+
+// ============================================================================
+// Poster Block Style
+// ============================================================================
+
+#let poster-block(title: none, body) = {
+  box(
+    width: 100%,
+    fill: white,
+    radius: 5pt,
+    stroke: none,
+    inset: 0pt,
+  )[
+    // Title
+    #if title != none [
+      #box(
+        width: 100%,
+        fill: npurple.lighten(85%),
+        radius: (top: 5pt),
+        inset: 12pt,
+      )[
+        #set text(weight: "bold", size: 28pt)
+        #title
+      ]
+    ]
+
+    // Body
+    #box(
+      width: 100%,
+      fill: white,
+      radius: if title != none { (bottom: 5pt) } else { 5pt },
+      inset: 15pt,
+    )[
+      #body
+    ]
+  ]
+}
+
+#let poster-example-block(title: none, body) = {
+  box(
+    width: 100%,
+    fill: white,
+    radius: 5pt,
+    stroke: none,
+  )[
+    // Title
+    #if title != none [
+      #box(
+        width: 100%,
+        fill: accent-teal.lighten(80%),
+        radius: (top: 5pt),
+        inset: 12pt,
+      )[
+        #set text(weight: "bold", size: 28pt)
+        #title
+      ]
+    ]
+
+    // Body
+    #box(
+      width: 100%,
+      fill: white,
+      radius: if title != none { (bottom: 5pt) } else { 5pt },
+      inset: 15pt,
+    )[
+      #body
+    ]
+  ]
+}
+
+// ============================================================================
+// Header (5cm tall)
+// ============================================================================
+
+#place(top)[
+  #box(
+    width: 100%,
+    height: 5cm,
+    fill: white,
+  )[
+    // Left logos (RF + France 2030)
+    #place(top + left, dx: 0.5cm, dy: 0.5cm)[
+      #image("images/rf.png", height: 3cm)
+      #h(0.3cm)
+      #image("images/f2030.png", height: 3cm)
+    ]
+
+    // Right logos (CEA, INRIA, CNRS)
+    #place(top + right, dx: -0.5cm, dy: 0.5cm)[
+      #image("images/cea.jpg", height: 3cm)
+      #h(0.3cm)
+      #image("images/inria.png", height: 3cm)
+      #h(0.3cm)
+      #image("images/cnrs.png", height: 3cm)
+    ]
+
+    // Title (centered)
+    #place(bottom + center, dy: -0.5cm)[
+      #set align(center)
+      #text(size: 60pt, weight: "bold", poster-title)
+      #v(0.3cm)
+      #text(size: 36pt, poster-author)
+    ]
+  ]
+]
+
+// ============================================================================
+// Footer (2cm tall)
+// ============================================================================
+
+#place(bottom)[
+  #box(
+    width: 100%,
+    height: 2cm,
+    fill: white,
+  )[
+    // Left logos
+    #place(bottom + left, dx: 0.5cm, dy: -0.25cm)[
+      #image("images/rf.png", height: 1.5cm)
+      #h(0.2cm)
+      #image("images/f2030.png", height: 1.5cm)
+    ]
+
+    // Right logos
+    #place(bottom + right, dx: -0.5cm, dy: -0.25cm)[
+      #image("images/cea.jpg", height: 1.5cm)
+      #h(0.2cm)
+      #image("images/inria.png", height: 1.5cm)
+      #h(0.2cm)
+      #image("images/cnrs.png", height: 1.5cm)
+    ]
+
+    // Center text
+    #place(center + horizon)[
+      #text(size: 20pt)[#poster-institution #h(2em) #poster-date]
+    ]
+  ]
+]
+
+// ============================================================================
+// Main Content Area
+// ============================================================================
+
+#place(top + center, dy: 5.5cm)[
+  #box(width: 90%, height: 100cm)[
+    #set text(size: 22pt)
+
+    #grid(
+      columns: (1fr, 1fr, 1fr),
+      gutter: 1.5cm,
+
+      // ========================================
+      // Column 1
+      // ========================================
+      [
+        #poster-block(title: "Theme Overview")[
+          The NumPEx theme is a Typst presentation and poster theme with minimal visual noise inspired by the French state graphic charter.
+
+          #v(0.3cm)
+
+          *Enable the theme by importing:*
+
+          ```typst
+          #import "numpex.typ": *
+          ```
+
+          #v(0.3cm)
+
+          See the French state graphic guidelines:
+
+          #align(center)[
+            #alert[#link("https://www.info.gouv.fr/marque-de-letat")[Charte graphique de l'État Français]]
+          ]
+        ]
+
+        #v(0.5cm)
+
+        #poster-block(title: "Sections & Typography")[
+          The theme provides sensible defaults for:
+
+          - _Emphasis_ on key text
+          - #alert[Accents] on important parts
+          - *Bold* for results
+
+          #v(0.5cm)
+
+          Typography uses the official Marianne font from the French government design system, with fallbacks for systems where it's not installed.
+        ]
+      ],
+
+      // ========================================
+      // Column 2
+      // ========================================
+      [
+        #poster-block(title: "Lists, Descriptions & Tables")[
+          *Lists:*
+          - Milk, Eggs, Potatoes
+
+          *Enumerations:*
+          + First
+          + Second
+          + Last
+
+          *Descriptions:*
+          / PowerPoint: Meeh.
+          / Beamer: Yeeeha.
+          / Typst: Even better!
+        ]
+
+        #v(0.5cm)
+
+        #poster-block(title: "Tables")[
+          #figure(
+            caption: [Largest cities in the world],
+            table(
+              columns: 2,
+              align: (left, right),
+              stroke: none,
+              table.hline(stroke: 1.5pt),
+              table.header([*City*], [*Population*]),
+              table.hline(stroke: 0.5pt),
+              [Mexico City], [20,116,842],
+              [Shanghai], [19,210,000],
+              [Peking], [15,796,450],
+              [Istanbul], [14,160,467],
+              table.hline(stroke: 1.5pt),
+            ),
+          )
+        ]
+      ],
+
+      // ========================================
+      // Column 3
+      // ========================================
+      [
+        #poster-block(title: "Blocks & Math")[
+          *Mathematics:*
+
+          $ e = lim_(n -> infinity) (1 + 1/n)^n $
+
+          #v(0.5cm)
+
+          The famous Euler identity:
+
+          $ e^(i pi) + 1 = 0 $
+        ]
+
+        #v(0.5cm)
+
+        #poster-example-block(title: "Example Block")[
+          This is an example block with teal styling.
+
+          Use it to highlight examples, tips, or supplementary information.
+        ]
+
+        #v(0.5cm)
+
+        #poster-block(title: "Code Example")[
+          ```fortran
+          program pippo
+            integer, parameter :: m=10, n=5
+            real(kind(1.d0)), allocatable :: a(:,:)
+            allocate(a(m,n))
+            call random_number(a)
+            call do_something(a)
+            write(*,'("Hello world")')
+            stop
+          end program pippo
+          ```
+        ]
+
+        #v(0.5cm)
+
+        #poster-block(title: "Conclusion")[
+          Get the source of this theme from:
+
+          #align(center)[
+            #text(size: 18pt)[
+              #link("https://github.com/numpex/presentation.template/")
+            ]
+          ]
+
+          #v(0.5cm)
+
+          *Typst advantages:*
+          - Sub-second compilation
+          - Cleaner syntax
+          - Hot reloading
+        ]
+      ],
+    )
+  ]
+]

--- a/presentation.template.typ
+++ b/presentation.template.typ
@@ -1,0 +1,245 @@
+// NumPEx Presentation Template for Typst
+// Equivalent to presentation.template.tex
+
+#import "numpex.typ": *
+
+#show: numpex-theme.with(
+  title: "A new presentation theme for NumPEx",
+  short-title: "NumPEx Theme",
+  author: "Christophe Prud'homme",
+  short-author: "C. Prud'homme",
+  date: datetime.today().display("[month repr:long] [day], [year]"),
+  institution: "Institute or miscellaneous information",
+  aspect-ratio: "16-9",
+)
+
+// ============================================================================
+// Title Slide
+// ============================================================================
+
+#title-slide(
+  title: "A new presentation theme for NumPEx",
+  subtitle: "This is a subtitle",
+  author: "Christophe Prud'homme",
+  date: datetime.today().display("[month repr:long] [day], [year]"),
+  institution: "Institute or miscellaneous information",
+)
+
+// ============================================================================
+// Introduction
+// ============================================================================
+
+#slide(title: "NumPEx theme")[
+  The NumPEx theme is a Beamer theme with minimal visual noise inspired by the
+
+  #align(center)[
+    #alert[#link("https://www.info.gouv.fr/marque-de-letat")[Charte graphique de l'etat Français]]
+  ]
+
+  Enable the theme by loading
+
+  #v(-0.2em)
+  #raw("\usetheme{numpex}", block: true, lang: "latex")
+  #v(-0.2em)
+
+  Note, that you have to have _Marianne_ font and XeTeX. Install it to enjoy this wonderful typography. You can find the font
+
+  #align(center)[
+    #alert[#link("https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-de-l-identite-de-l-etat/typographie/")[here]]
+  ]
+]
+
+#slide(title: "Sections")[
+  Sections group slides of the same topic. Use the section-slide function:
+
+  ```typst
+  #section-slide("Elements")
+  ```
+
+  which creates a full-page section break with the NumPEx styling...
+]
+
+// ============================================================================
+// Section: Elements
+// ============================================================================
+
+#section-slide("Elements")
+
+#slide(title: "Typography")[
+  The theme provides sensible defaults to _emphasize_
+  text, #alert[accent] parts or show *bold* results.
+
+  #v(1em)
+
+  - Regular text appears in Marianne font (or fallback)
+  - #alert[Alerted text] uses the French red color
+  - _Emphasized text_ is italicized
+  - *Bold text* for strong emphasis
+]
+
+#slide(title: "Lists")[
+  #grid(
+    columns: (1fr, 1fr),
+    gutter: 2em,
+
+    [
+      *Items*
+      - Milk
+      - Eggs
+      - Potatoes
+    ],
+
+    [
+      *Enumerations*
+      + First,
+      + Second and
+      + Last.
+    ],
+  )
+]
+
+#slide(title: "Descriptions")[
+  #set terms(separator: [ --- ])
+
+  / PowerPoint: Meeh.
+  / Beamer: Yeeeha.
+  / Typst: Even better!
+]
+
+#slide(title: "Tables")[
+  #figure(
+    caption: [Largest cities in the world (source: Wikipedia)],
+    table(
+      columns: 2,
+      align: (left, right),
+      table.hline(stroke: 1.5pt),
+      table.header([*City*], [*Population*]),
+      table.hline(stroke: 0.5pt),
+      [Mexico City], [20,116,842],
+      [Shanghai], [19,210,000],
+      [Peking], [15,796,450],
+      [Istanbul], [14,160,467],
+      table.hline(stroke: 1.5pt),
+    ),
+  )
+]
+
+#slide(title: "Blocks")[
+  #block(title: "This is a block title")[
+    Hello
+  ]
+
+  #example-block(title: "This is an example block")[
+    Hello
+  ]
+]
+
+#slide(title: "Math")[
+  Euler's limit definition of $e$:
+
+  $ e = lim_(n -> infinity) (1 + 1/n)^n $
+
+  #v(1em)
+
+  And the famous identity:
+
+  $ e^(i pi) + 1 = 0 $
+]
+
+#slide(title: "Line plots")[
+  #import "@preview/cetz:0.3.4": canvas, draw
+
+  #align(center)[
+    #canvas(length: 0.8cm, {
+      import draw: *
+
+      // Grid
+      for x in range(0, 5) {
+        line((x, -1), (x, 4), stroke: gray + 0.3pt)
+      }
+      for y in range(-1, 5) {
+        line((0, y), (4, y), stroke: gray + 0.3pt)
+      }
+
+      // Axes
+      line((-0.2, 0), (4.2, 0), mark: (end: ">"), stroke: black)
+      line((0, -1.2), (0, 4.2), mark: (end: ">"), stroke: black)
+      content((4.4, 0), $x$)
+      content((0, 4.5), $f(x)$)
+
+      // f(x) = x (red)
+      line((0, 0), (3.5, 3.5), stroke: red)
+      content((3.8, 3.5), $f(x) = x$, anchor: "west")
+
+      // f(x) = sin(x) approximation (blue)
+      let sin-points = ()
+      for i in range(0, 40) {
+        let x = i * 0.1
+        let y = calc.sin(x)
+        sin-points.push((x, y))
+      }
+      line(..sin-points, stroke: blue)
+      content((4.2, 0.7), $f(x) = sin x$, anchor: "west")
+
+      // f(x) = exp(x)/20 (orange)
+      let exp-points = ()
+      for i in range(0, 35) {
+        let x = i * 0.1
+        let y = 0.05 * calc.exp(x)
+        exp-points.push((x, y))
+      }
+      line(..exp-points, stroke: orange)
+      content((3.8, 1.7), $f(x) = 1/20 e^x$, anchor: "west")
+    })
+  ]
+]
+
+#slide(title: "Code")[
+  I love Fortran!
+
+  #v(0.5cm)
+
+  ```fortran
+  program pippo
+
+    integer, parameter            :: m=10, n=5
+    real(kind(1.d0)), allocatable :: a(:,:)
+
+    allocate(a(m,n))      ! allocate the matrix
+
+    call random_number(a) ! fill it up
+
+    call do_something(a)  ! do something on it
+
+    write(*,'("Hello world")')
+    stop
+
+  end program pippo
+  ```
+]
+
+// ============================================================================
+// Section: Conclusion
+// ============================================================================
+
+#section-slide("Conclusion")
+
+#slide(title: "Summary")[
+  Get the source of this theme and the demo presentation from
+
+  #v(1em)
+
+  #align(center)[
+    #link("https://github.com/numpex/presentation.template/")
+  ]
+
+  #v(1em)
+
+  *Typst advantages:*
+  - Much faster compilation (sub-second)
+  - Cleaner syntax
+  - Built-in package manager
+  - Hot reloading with `typst watch`
+]
+
+#plain-slide(title: "Questions?")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,25 +1,34 @@
 [project]
 name = "presentation-template"
-version = "1.0.0"
-description = "NumPEx Beamer presentation template"
+version = "1.1.0"
+description = "NumPEx presentation and poster templates for LaTeX/Beamer and Typst"
 
 [tool.article-cli]
 # Project configuration
 [tool.article-cli.project]
 type = "presentation"
+engines = ["latex", "typst"]
 
 [tool.article-cli.presentation]
 theme = "numpex"
 aspect_ratio = "169"
 
 [tool.article-cli.documents]
+# LaTeX documents
 main = "presentation.template.tex"
 additional = ["poster.template.tex"]
+# Typst documents
+main_typst = "presentation.template.typ"
+additional_typst = ["poster.template.typ"]
 
 [tool.article-cli.latex]
 engine = "xelatex"
 shell_escape = true
-build_dir = "build"
+build_dir = "build/tex"
+
+[tool.article-cli.typst]
+font_paths = ["fonts/Marianne/desktop", "fonts/Roboto/static"]
+build_dir = "build/typst"
 
 [tool.article-cli.workflow]
 output_dir = "build"
@@ -36,3 +45,13 @@ sources = [
     { name = "Roboto", url = "https://github.com/googlefonts/roboto/releases/download/v2.138/roboto-unhinted.zip", description = "Google's sans-serif font family" },
     { name = "Roboto Mono", url = "https://github.com/googlefonts/RobotoMono/archive/refs/heads/main.zip", description = "Google's monospace font, good for code" }
 ]
+
+[tool.article-cli.theme]
+name = "numpex"
+latex_files = [
+    "beamerthemenumpex.sty",
+    "beamercolorthemenumpex.sty",
+    "beamerfontthemenumpex.sty"
+]
+typst_files = ["numpex.typ"]
+shared_directories = ["images", "fonts"]


### PR DESCRIPTION
- Updated .vscode/settings.json to include Typst formatter and enable format on save.
- Created .vscode/tasks.json for Typst build and watch tasks for presentations and posters.
- Added Makefile to support both LaTeX and Typst builds with separate output directories.
- Updated README.md to include Typst usage instructions and VS Code setup.
- Introduced numpex.typ as the Typst presentation theme based on the French State Graphic Charter.
- Created poster.template.typ for Typst, equivalent to the LaTeX poster template.
- Created presentation.template.typ for Typst, equivalent to the LaTeX presentation template.
- Updated pyproject.toml to include Typst as a supported engine and configure font paths.

Add Typst support for presentations and posters
- closes #11